### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: dtolnay/rust-toolchain@1.82.0
       with:
         components: clippy
@@ -17,7 +17,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: dtolnay/rust-toolchain@1.81.0
       with:
         components: rustfmt

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master
@@ -38,7 +38,7 @@ jobs:
       run: cargo llvm-cov --features=magic-module,rules-profiling --workspace --lib --lcov --output-path lcov.info
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       statuses: write
     steps:
-    - uses: aslafy-z/conventional-pr-title-action@v3
+    - uses: aslafy-z/conventional-pr-title-action@a0b851005a0f82ac983a56ead5a8111c0d8e044a  # v3.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -87,7 +87,7 @@ jobs:
         fi
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
       with:
         name: yr-${{ matrix.target }}
         path: yara-x-*
@@ -120,7 +120,7 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -137,7 +137,7 @@ jobs:
         fi
 
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.12'
 
@@ -178,13 +178,13 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: '10.12'
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
       with:
         name: pypi-${{ matrix.build }}-${{ matrix.python-version }}
         path: ./wheelhouse/*.whl
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
       with:
         name: pypi-source-${{ strategy.job-index }}
         path: ./wheelhouse/*.tar.gz
@@ -195,7 +195,7 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9
       with:
         pattern: yr-*
 
@@ -204,7 +204,7 @@ jobs:
       run: ls
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
       with:
         draft: true
         files: yr-*/yara-x-*
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Publish crate
       env:
@@ -241,7 +241,7 @@ jobs:
       id-token: write
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9
       with:
         pattern: pypi-*
         merge-multiple: true

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -36,16 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
       with:
         node-version: '18'
         cache: 'npm'
         cache-dependency-path: 'site'
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
     - name: Install dependencies
       run: |
         cd site
@@ -63,7 +63,7 @@ jobs:
           --minify \
           --baseURL "${{ steps.pages.outputs.base_url }}/"
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
       with:
         path: ./site/public
 
@@ -77,4 +77,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,10 +102,10 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Setup cache
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
       with:
         path: |
           ~/.cargo/registry


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `codecov/codecov-action`
  * From: v4 ()
  * To: v5.4.0 (0565863a31f2c772f9f0395002a31e3f06189574)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-go`
  * From: v5 ()
  * To: v5.3.0 (f111f3307d8850f501ac008e886eec1fd1932a34)

* `aslafy-z/conventional-pr-title-action`
  * From: v3 ()
  * To: v3.2.0 (a0b851005a0f82ac983a56ead5a8111c0d8e044a)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-python`
  * From: v5 ()
  * To: v5.4.0 (42375524e23c412d93fb67b49958b491fce71c38)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/upload-artifact`
  * From: v4 ()
  * To: v4.6.1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-python`
  * From: v5 ()
  * To: v5.4.0 (42375524e23c412d93fb67b49958b491fce71c38)

* `actions/upload-artifact`
  * From: v4 ()
  * To: v4.6.1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)

* `actions/upload-artifact`
  * From: v4 ()
  * To: v4.6.1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)

* `actions/download-artifact`
  * From: v4 ()
  * To: v4.1.9 (cc203385981b70ca67e1cc392babf9cc229d5806)

* `softprops/action-gh-release`
  * From: v2 ()
  * To: v2.2.1 (c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/download-artifact`
  * From: v4 ()
  * To: v4.1.9 (cc203385981b70ca67e1cc392babf9cc229d5806)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-node`
  * From: v4 ()
  * To: v4.2.0 (1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a)

* `actions/configure-pages`
  * From: v4 ()
  * To: v5.0.0 (983d7736d9b0ae728b81ab479565c72886d7745b)

* `actions/upload-pages-artifact`
  * From: v3 ()
  * To: v3.0.1 (56afc609e74202658d3ffba0e8f6dda462b719fa)

* `actions/deploy-pages`
  * From: v4 ()
  * To: v4.0.5 (d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/cache`
  * From: v4 ()
  * To: v4.2.2 (d4323d4df104b026a6aa633fdb11d772146be0bf)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.